### PR TITLE
Rename vhx-ruby to vhx

### DIFF
--- a/vhx.gemspec
+++ b/vhx.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'vhx/version'
 
 Gem::Specification.new do |spec|
-  spec.name           = 'vhx-ruby'
+  spec.name           = 'vhx'
   spec.version        = Vhx::VERSION
   spec.authors        = ['Sagar Shah', 'Kevin Sheurs']
   spec.date           = '2017-02-03'


### PR DESCRIPTION
It's weird when your gem is named differently to it's internal namespace.